### PR TITLE
Fixed absolute path for model loader

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,7 +14,10 @@ from sklearn.linear_model import LinearRegression
 
 app = Flask(__name__)
 CORS(app)
-model = load_model('C:/DS/Stock-Analyzer/backend/Model.keras')
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+model_path = os.path.join(current_dir, 'Model.keras')
+model = load_model(model_path)
 
 cleaned_data_cache = {}
 


### PR DESCRIPTION
##  Fix: Hardcoded Absolute Path in Model Loader

###  What Changed
Replaced the hardcoded absolute path:
```python
model = load_model('C:/DS/Stock-Analyzer/backend/Model.keras')
```
with a relative and portable path using `os.path`.

### ✅ Why
Using a hardcoded path breaks the app for anyone who doesn't have the same file structure. A relative path ensures portability and better practice.

### 🔗 Related Issue
Fixes #7

---
Let me know if changes are needed!
